### PR TITLE
Support exclusion of certain projects from analysis

### DIFF
--- a/src/sbt-test/test-projects/multi-module-project/build.sbt
+++ b/src/sbt-test/test-projects/multi-module-project/build.sbt
@@ -121,4 +121,8 @@ lazy val thirdService = sbt
 lazy val fourthService = sbt
   .Project("service-4", service / "service-4")
   .dependsOn(firstTool, secondTool)
+  .dependsOn(testKit % Test)
   .settings(settings("service-4"))
+
+lazy val testKit = sbt
+  .Project("testKit", libs / "testKit")

--- a/src/sbt-test/test-projects/multi-module-project/build.sbt
+++ b/src/sbt-test/test-projects/multi-module-project/build.sbt
@@ -18,7 +18,7 @@ commands += Command("addEnvVar")(_ => sbt.internal.util.complete.Parsers.spaceDe
 // Projects
 //                               +-----------+                        +-----------+
 //                               |           |                        |           |
-//                               |   lib-1   +<---------+  +--------->+   lib-2   |
+//                               |   lib-1   +<---------+  +--------->+ lib-2 (X) |
 //                               |           |          |  |          |           |
 //                               +-----^-----+          |  |          +---+-------+
 //                                     |                |  |              ^
@@ -80,6 +80,7 @@ lazy val firstLib = sbt
 lazy val secondLib = sbt
   .Project("lib-2", libs / "lib-2")
   .settings(settings("lib-2"))
+  .settings(com.elarib.BuildKeys.partialSbtExcludedProject := ())
 
 //Tools
 lazy val firstTool = sbt

--- a/src/sbt-test/test-projects/multi-module-project/build.sbt
+++ b/src/sbt-test/test-projects/multi-module-project/build.sbt
@@ -80,7 +80,7 @@ lazy val firstLib = sbt
 lazy val secondLib = sbt
   .Project("lib-2", libs / "lib-2")
   .settings(settings("lib-2"))
-  .settings(com.elarib.BuildKeys.partialSbtExcludedProject := ())
+  .settings(com.elarib.BuildKeys.partialSbtOpaqueProject := ())
 
 //Tools
 lazy val firstTool = sbt

--- a/src/sbt-test/test-projects/multi-module-project/build.sbt
+++ b/src/sbt-test/test-projects/multi-module-project/build.sbt
@@ -83,6 +83,10 @@ lazy val secondLib = sbt
   .settings(com.elarib.BuildKeys.partialSbtOpaqueProject := ())
 
 //Tools
+lazy val toolsProject = sbt
+  .Project("tools", tools)
+  .settings(settings("tools"))
+
 lazy val firstTool = sbt
   .Project("tool-1", tools / "tool-1")
   .dependsOn(firstLib)

--- a/src/sbt-test/test-projects/multi-module-project/changes/6.log
+++ b/src/sbt-test/test-projects/multi-module-project/changes/6.log
@@ -1,0 +1,1 @@
+src/libs/testKit/build.sbt

--- a/src/sbt-test/test-projects/multi-module-project/expected/4.log
+++ b/src/sbt-test/test-projects/multi-module-project/expected/4.log
@@ -1,5 +1,6 @@
-6 projects have been changed
+7 projects have been changed
 lib-1
+lib-2
 service-1
 service-3
 service-4

--- a/src/sbt-test/test-projects/multi-module-project/expected/4.log
+++ b/src/sbt-test/test-projects/multi-module-project/expected/4.log
@@ -1,10 +1,7 @@
-9 projects have been changed
+6 projects have been changed
 lib-1
-lib-2
 service-1
-service-2
 service-3
 service-4
 tool-1
-tool-2
 tool-3

--- a/src/sbt-test/test-projects/multi-module-project/expected/5.log
+++ b/src/sbt-test/test-projects/multi-module-project/expected/5.log
@@ -1,5 +1,5 @@
-Metabuild files have changed. Need to reload all the 11 projects
-11 projects have been changed
+Metabuild files have changed. Need to reload all the 12 projects
+12 projects have been changed
 lib-1
 lib-2
 multi-module-project
@@ -7,6 +7,7 @@ service-1
 service-2
 service-3
 service-4
+testKit
 tool-1
 tool-2
 tool-3

--- a/src/sbt-test/test-projects/multi-module-project/expected/5.log
+++ b/src/sbt-test/test-projects/multi-module-project/expected/5.log
@@ -1,5 +1,5 @@
-Metabuild files have changed. Need to reload all the 10 projects
-10 projects have been changed
+Metabuild files have changed. Need to reload all the 11 projects
+11 projects have been changed
 lib-1
 lib-2
 multi-module-project
@@ -10,3 +10,4 @@ service-4
 tool-1
 tool-2
 tool-3
+tools

--- a/src/sbt-test/test-projects/multi-module-project/expected/6.log
+++ b/src/sbt-test/test-projects/multi-module-project/expected/6.log
@@ -1,0 +1,2 @@
+1 projects have been changed
+testKit

--- a/src/sbt-test/test-projects/multi-module-project/test
+++ b/src/sbt-test/test-projects/multi-module-project/test
@@ -24,3 +24,8 @@ $ must-mirror ./result4.log ./expected/4.log
 > addEnvVar PARTIAL_SBT_LOG_PATH result5.log
 > changedProjects dummyChanges ./changes/5.log
 $ must-mirror ./result5.log ./expected/5.log
+# 6th test
+> reload
+> addEnvVar PARTIAL_SBT_LOG_PATH result6.log
+> changedProjectsInCompile dummyChanges ./changes/6.log
+$ must-mirror ./result6.log ./expected/6.log


### PR DESCRIPTION
A project marked with `partialSbtOpaqueProject` setting will not contribute to invalidation of its dependent projects.

Given:
`a <- b <- c`
`     b <- d`
`c` is marked as excluded

Then:
1. If we change only `c` — `c` gets reported.
2. If we change only `d` — `a`, `b` and `d` get reported
3. If we change both `c` and `d` — `a`, `b`, `c` and `d` get reported